### PR TITLE
Fixes security issue on handling a failed `password_hash`

### DIFF
--- a/lib/Exception/InactivePassException.php
+++ b/lib/Exception/InactivePassException.php
@@ -19,6 +19,6 @@ final class InactivePassException extends Exception
     /** Class constructor */
     public function __construct()
     {
-        return parent::__construct('Inactive Pass');
+        parent::__construct('Inactive Pass');
     }
 }

--- a/lib/Exception/InvalidPasswordException.php
+++ b/lib/Exception/InvalidPasswordException.php
@@ -19,6 +19,6 @@ final class InvalidPasswordException extends Exception
     /** Class Constructor */
     public function __construct()
     {
-        return parent::__construct('An invalid password as been given');
+        parent::__construct('An invalid password as been given');
     }
 }

--- a/lib/Handler/BasicPasswordHandler.php
+++ b/lib/Handler/BasicPasswordHandler.php
@@ -30,12 +30,20 @@ class BasicPasswordHandler implements PasswordHandlerInterface
         $this->hash = $hash;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * @throws \RuntimeException
+     */
     public static function hash($password, array $options = [])
     {
         $hash = password_hash($password, PASSWORD_DEFAULT, $options);
 
-        return new self($hash);
+        if ($hash !== false) {
+            return new self($hash);
+        }
+
+        throw new \RuntimeException('Unsuccessful `password_hash` function call');
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
There was an issue where `password_hash` could fail. Please see #4. Also adds some general tidy up on the exceptions.
